### PR TITLE
fix(CodeQL): Potential fix for code scanning alert #2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export function collectEntriesFromDist(
     ".d.ts",
   ];
   const regex = new RegExp(
-    `\.(${entryPointExtensions.map((ext) => ext.slice(1)).join("|")})`
+    `\\.(${entryPointExtensions.map((ext) => ext.slice(1)).join("|")})`
   );
   const files = fs.readdirSync(distPath).filter((f) => regex.test(f));
   const entryNames = [...new Set(files.map((f) => f.replace(regex, "")))];


### PR DESCRIPTION
Potential fix for [https://github.com/breningham/vite-plugin-exports-updater/security/code-scanning/2](https://github.com/breningham/vite-plugin-exports-updater/security/code-scanning/2)

To fix the problem, the regular expression string should be constructed so that the pattern matches a literal dot before the extension. In JavaScript string literals, to represent a literal backslash in the resulting RegExp pattern, you must escape it as `\\.`. Therefore, the pattern string should be `` `\\.(${...})` ``. This change should be made in the `collectEntriesFromDist` function, specifically on line 65 of `src/index.ts`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
