### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/breningham/vite-plugin-exports-updater/security/code-scanning/1](https://github.com/breningham/vite-plugin-exports-updater/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the `build` job in `.github/workflows/ci.yml` to restrict the `GITHUB_TOKEN` to the minimum required permissions. Since the `build` job only needs to read repository contents (for checkout and installing dependencies), set `permissions: contents: read` under the `build` job. This change should be made directly under the `build:` job definition, before the `runs-on` key (i.e., after line 12 and before line 13). No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
