### PR TITLE
feat: component based exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   "volta": {
     "node": "24.6.0",
     "pnpm": "10.14.0"
+  },
+  "dependencies": {
+    "glob": "^11.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      glob:
+        specifier: ^11.0.3
+        version: 11.0.3
     devDependencies:
       '@semantic-release/changelog':
         specifier: ^6.0.3
@@ -287,6 +291,18 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -673,6 +689,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -859,8 +879,14 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
@@ -1031,6 +1057,10 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
@@ -1077,6 +1107,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1245,6 +1280,10 @@ packages:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
     engines: {node: ^18.17 || >=20.6.1}
 
+  jackspeak@4.1.1:
+    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
+    engines: {node: 20 || >=22}
+
   java-properties@1.0.2:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
@@ -1333,6 +1372,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -1375,6 +1418,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  minimatch@10.0.3:
+    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1384,6 +1431,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1563,6 +1614,9 @@ packages:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1607,6 +1661,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1800,12 +1858,20 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2074,6 +2140,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -2253,6 +2323,21 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2694,6 +2779,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.1: {}
+
   any-promise@1.3.0: {}
 
   argparse@2.0.1: {}
@@ -2871,7 +2958,11 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  eastasianwidth@0.2.0: {}
+
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   emojilib@2.4.0: {}
 
@@ -3104,6 +3195,11 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   from2@2.3.0:
     dependencies:
       inherits: 2.0.4
@@ -3149,6 +3245,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.1.1
+      minimatch: 10.0.3
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.0
 
   globals@14.0.0: {}
 
@@ -3285,6 +3390,10 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.uniqby: 4.7.0
 
+  jackspeak@4.1.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+
   java-properties@1.0.2: {}
 
   jiti@2.5.1:
@@ -3361,6 +3470,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.1.0: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3395,6 +3506,10 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  minimatch@10.0.3:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -3404,6 +3519,8 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@7.1.2: {}
 
   ms@2.1.3: {}
 
@@ -3502,6 +3619,8 @@ snapshots:
 
   p-try@1.0.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3541,6 +3660,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.1.0
+      minipass: 7.1.2
 
   path-type@4.0.0: {}
 
@@ -3764,6 +3888,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -3771,6 +3901,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
 
   strip-bom@3.0.0: {}
 
@@ -4005,6 +4139,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   xtend@4.0.2: {}
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -103,11 +103,11 @@ describe('buildExportsMap', () => {
     const entryNames = ['index'];
     vi.spyOn(path, 'basename').mockReturnValue('my-pkg');
     vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return p === '/path/to/dist/index.js';
+      return p === '/path/to/dist/index.js' || p.toString().endsWith('dist');
     });
     vi.spyOn(fs, 'readdirSync').mockReturnValue(['style.css'] as any);
 
-    const exportsMap = buildExportsMap(entryNames, distPath, pkg, {});
+    const exportsMap = buildExportsMap(entryNames, distPath, pkg, { css: true });
 
     expect(exportsMap).toEqual({
       '.': {
@@ -121,7 +121,7 @@ describe('buildExportsMap', () => {
     const entryNames = ['index'];
     vi.spyOn(path, 'basename').mockReturnValue('my-pkg');
     vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return p === '/path/to/dist/index.js';
+      return p === '/path/to/dist/index.js' || p.toString().endsWith('dist');
     });
     vi.spyOn(fs, 'readdirSync').mockReturnValue(['style.css'] as any);
 
@@ -138,7 +138,7 @@ describe('buildExportsMap', () => {
     const entryNames = ['index'];
     vi.spyOn(path, 'basename').mockReturnValue('my-pkg');
     vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return p === '/path/to/dist/index.js';
+      return p === '/path/to/dist/index.js' || p.toString().endsWith('dist');
     });
     vi.spyOn(fs, 'readdirSync').mockReturnValue(['style.css'] as any);
 
@@ -157,7 +157,7 @@ describe('buildExportsMap', () => {
     const entryNames = ['index'];
     vi.spyOn(path, 'basename').mockReturnValue('my-pkg');
     vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return p === '/path/to/dist/index.js';
+      return p === '/path/to/dist/index.js' || p.toString().endsWith('dist');
     });
     vi.spyOn(fs, 'readdirSync').mockReturnValue(['style.scss'] as any);
 
@@ -177,7 +177,7 @@ describe('buildExportsMap', () => {
     const entryNames = ['index'];
     vi.spyOn(path, 'basename').mockReturnValue('my-pkg');
     vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return p === '/path/to/dist/index.js';
+      return p === '/path/to/dist/index.js' || p.toString().endsWith('dist');
     });
     vi.spyOn(fs, 'readdirSync').mockReturnValue(['style.css'] as any);
 
@@ -195,7 +195,7 @@ describe('buildExportsMap', () => {
     const entryNames = ['index'];
     vi.spyOn(path, 'basename').mockReturnValue('my-pkg');
     vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return p === '/path/to/dist/index.js';
+      return p === '/path/to/dist/index.js' || p.toString().endsWith('dist');
     });
     vi.spyOn(fs, 'readdirSync').mockReturnValue(['style.scss'] as any);
     vi.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as any);
@@ -216,7 +216,11 @@ describe('buildExportsMap', () => {
     const entryNames = ['index'];
     vi.spyOn(path, 'basename').mockReturnValue('my-pkg');
     vi.spyOn(fs, 'existsSync').mockImplementation((p) => {
-      return p === '/path/to/dist/index.js';
+      const pathStr = p.toString();
+      if (pathStr.endsWith('index.js')) return true;
+      if (pathStr.endsWith('dist')) return true;
+      if (pathStr.endsWith('styles')) return true;
+      return false;
     });
     // Mock readdirSync to return a directory and a file
     vi.spyOn(fs, 'readdirSync').mockImplementation((p) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,14 +10,13 @@ interface PackageJson {
   exports?: Record<string, ExportCondition>;
 }
 
-type ExportCondition =
-  | string
-  | {
-      import?: string;
-      require?: string;
-      types?: string;
-    }
-  | { sass: string };
+type ExportCondition = {
+  import?: string;
+  require?: string;
+  types?: string;
+  sass?: string;
+  style?: string;
+};
 
 // --- Helper Functions (from your original script) ---
 

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -1,8 +1,18 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import updateExports from "./index";
 import fs from "node:fs";
+import { globSync } from "glob";
+import { loadConfigFromFile } from "vite";
 
 vi.mock("node:fs");
+vi.mock("glob");
+vi.mock("vite", async (importOriginal) => {
+  const original = await importOriginal<typeof import("vite")>();
+  return {
+    ...original,
+    loadConfigFromFile: vi.fn(),
+  };
+});
 
 describe("vite-plugin-exports-updater", () => {
   it("should update package.json on closeBundle", async () => {
@@ -25,7 +35,16 @@ describe("vite-plugin-exports-updater", () => {
       "index.js",
       "index.d.ts",
     ] as any);
-    vi.spyOn(fs, "statSync").mockReturnValue({ isDirectory: () => false } as any);
+    vi.spyOn(fs, "statSync").mockReturnValue({
+      isDirectory: () => false,
+    } as any);
+
+    // Mock loadConfigFromFile to return a config without named entries
+    vi.mocked(loadConfigFromFile).mockResolvedValue({
+      path: "/path/to/project/vite.config.ts",
+      config: { build: { lib: { entry: "src/index.ts" } } },
+      dependencies: [],
+    });
 
     if (typeof closeBundle === "function") {
       await closeBundle.call(undefined);
@@ -49,5 +68,132 @@ describe("vite-plugin-exports-updater", () => {
         2
       ) + "\n"
     );
+  });
+});
+
+describe("vite-plugin-exports-updater with component exports", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // --- Mock CWD and package.json ---
+    vi.spyOn(process, "cwd").mockReturnValue("/path/to/project");
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      JSON.stringify({ name: "my-component-lib" })
+    );
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+    // --- Mock Vite Config ---
+    vi.mocked(loadConfigFromFile).mockResolvedValue({
+      path: "/path/to/project/vite.config.ts",
+      config: {
+        build: {
+          lib: {
+            entry: {
+              button: "lib/button/index.ts",
+              card: "lib/card/index.ts",
+            },
+          },
+        },
+      },
+      dependencies: [],
+    });
+
+    // --- Mock File System ---
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      const pathStr = p.toString();
+      // Assume package.json and dist folder always exist
+      if (pathStr.endsWith("package.json")) return true;
+      if (pathStr.endsWith("dist")) return true;
+
+      // CJS builds exist
+      if (
+        ["dist/button.cjs", "dist/card.cjs"].some((file) =>
+          pathStr.endsWith(file)
+        )
+      )
+        return true;
+
+      // Type files for button component (for handleTypes test)
+      if (pathStr.endsWith("dist/types/button.d.ts")) return true;
+
+      return false;
+    });
+
+    // --- Mock Glob ---
+    vi.mocked(globSync).mockImplementation((pattern, options) => {
+      const cwd = options?.cwd?.toString() || "";
+      if (cwd.endsWith("lib/button")) {
+        return ["_button.scss"];
+      }
+      if (cwd.endsWith("lib/card")) {
+        return ["card.css"];
+      }
+      return [];
+    });
+  });
+
+  it("should generate exports with types and sass/style conditions", async () => {
+    const plugin = updateExports({ handleTypes: true });
+    const closeBundle = plugin.closeBundle;
+
+    if (typeof closeBundle === "function") {
+      await closeBundle.call(undefined);
+    }
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "/path/to/project/package.json",
+      JSON.stringify(
+        {
+          name: "my-component-lib",
+          exports: {
+            "./button": {
+              import: "./dist/button.js",
+              require: "./dist/button.cjs",
+              types: "./dist/types/button.d.ts",
+              sass: "lib/button/_button.scss",
+            },
+            "./card": {
+              import: "./dist/card.js",
+              require: "./dist/card.cjs",
+              style: "lib/card/card.css",
+            },
+          },
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  });
+
+  it("should NOT generate types condition if handleTypes is false", async () => {
+    const plugin = updateExports({ handleTypes: false }); // Or just updateExports()
+    const closeBundle = plugin.closeBundle;
+
+    if (typeof closeBundle === "function") {
+      await closeBundle.call(undefined);
+    }
+
+    const writtenConfig = JSON.parse(
+      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string
+    );
+
+    expect(writtenConfig.exports["./button"]).not.toHaveProperty("types");
+    expect(writtenConfig.exports["./button"]).toHaveProperty("sass");
+  });
+
+  it("should NOT generate style/sass conditions if css is false", async () => {
+    const plugin = updateExports({ css: false });
+    const closeBundle = plugin.closeBundle;
+
+    if (typeof closeBundle === "function") {
+      await closeBundle.call(undefined);
+    }
+
+    const writtenConfig = JSON.parse(
+      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string
+    );
+
+    expect(writtenConfig.exports["./button"]).not.toHaveProperty("sass");
+    expect(writtenConfig.exports["./card"]).not.toHaveProperty("style");
   });
 });


### PR DESCRIPTION
This PR introduces an automated, convention-based system for generating package.json exports for component libraries. This change streamlines the export process, which was previously manual and prone to errors.

Key features include:

- Automatic asset discovery: The plugin now leverages Vite's build.lib.entry to find components and their assets.

- Enhanced CSS handling: Automatically scans for and exports .css and .scss files, including a separate top-level export for non-module .css files to improve tooling compatibility. It also explicitly ignores CSS Modules (.module.css and .module.scss).

- Backward compatibility: Retains the previous functionality of scanning the dist directory for non-component library builds.

This change enables more intuitive imports for consumers, like my-lib/button, and ensures more precise and compatible export maps for various asset types.

NOTE: This PR includes a fix to refine the CSS export mapping and ignore CSS modules, which was addressed in a follow-up commit.