### PR TITLE
fix(plugin): use relative paths instead of absolute paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,10 +110,11 @@ export function buildComponentExportsFromViteConfig(
       });
       for (const file of styleFiles) {
         const ext = path.extname(file);
+        const relativePath = `./${path.relative(pkgDir, path.join(componentDir, file)).replace(/\\/g, "/")}`;
         if (ext === ".scss") {
-          conditions.sass = path.join(componentDir, file).replace(/\\/g, "/");
+          conditions.sass = relativePath;
         } else if (ext === ".css") {
-          conditions.style = path.join(componentDir, file).replace(/\\/g, "/");
+          conditions.style = relativePath;
         }
       }
     }

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -89,9 +89,10 @@ describe("vite-plugin-exports-updater with component exports", () => {
         build: {
           lib: {
             entry: {
-              button: "lib/button/index.ts",
-              card: "lib/card/index.ts",
-              "css-module-component": "lib/css-module-component/index.ts",
+              button: "/path/to/project/lib/button/index.ts",
+              card: "/path/to/project/lib/card/index.ts",
+              "css-module-component":
+                "/path/to/project/lib/css-module-component/index.ts",
             },
           },
         },
@@ -137,10 +138,12 @@ describe("vite-plugin-exports-updater with component exports", () => {
       }
 
       // Filter out ignored files
-      return files.filter(file => {
-        return !ignorePatterns.some(ignorePattern => {
+      return files.filter((file) => {
+        return !ignorePatterns.some((ignorePattern) => {
           // Basic glob matching for testing purposes
-          const regex = new RegExp(ignorePattern.replace(/\./g, "\\.").replace(/\*/g, ".*"));
+          const regex = new RegExp(
+            ignorePattern.replace(/\./g, "\\.").replace(/\*/g, ".*")
+          );
           return regex.test(file);
         });
       });
@@ -165,14 +168,14 @@ describe("vite-plugin-exports-updater with component exports", () => {
               import: "./dist/button.js",
               require: "./dist/button.cjs",
               types: "./dist/types/button.d.ts",
-              sass: "lib/button/_button.scss",
+              sass: "./lib/button/_button.scss",
             },
             "./card": {
               import: "./dist/card.js",
               require: "./dist/card.cjs",
-              style: "lib/card/card.css",
+              style: "./lib/card/card.css",
             },
-            "./card.css": "lib/card/card.css", // New direct CSS export
+            "./card.css": "./lib/card/card.css", // New direct CSS export
             "./css-module-component": {
               import: "./dist/css-module-component.js",
               require: "./dist/css-module-component.cjs",


### PR DESCRIPTION
The plugin was previously generating absolute paths for the `sass` and `style` conditions in the `package.json` exports map when using component-based entries. This was caused by incorrectly joining paths without making them relative to the package root.

This change corrects the behavior by using `path.relative` to ensure that the generated paths are always relative to the package root, as required by the `exports` field specification.

Additionally, the relevant test case has been updated to use absolute paths in its mocks to accurately reflect real-world usage and prevent future regressions.
