### PR TITLE
feat(plugin): add `development` exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,10 +105,7 @@ export function buildComponentExportsFromViteConfig(
     }
 
     if (options.enabledDevelopment) {
-      conditions.development = path.relative(
-        pkgDir,
-        path.join(entryPath, name)
-      );
+      conditions.development = `./${path.relative(pkgDir, entryPath)}`;
     }
 
     // Smart style detection

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -151,7 +151,10 @@ describe("vite-plugin-exports-updater with component exports", () => {
   });
 
   it("should generate exports with types and sass/style conditions, and direct CSS export", async () => {
-    const plugin = updateExports({ handleTypes: true });
+    const plugin = updateExports({
+      handleTypes: true,
+      enabledDevelopment: false,
+    });
     const closeBundle = plugin.closeBundle;
 
     if (typeof closeBundle === "function") {
@@ -179,6 +182,50 @@ describe("vite-plugin-exports-updater with component exports", () => {
             "./css-module-component": {
               import: "./dist/css-module-component.js",
               require: "./dist/css-module-component.cjs",
+            },
+          },
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  });
+
+  it("should generate exports with development conditions", async () => {
+    const plugin = updateExports({
+      handleTypes: true,
+      enabledDevelopment: true,
+    });
+    const closeBundle = plugin.closeBundle;
+
+    if (typeof closeBundle === "function") {
+      await closeBundle.call(undefined);
+    }
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "/path/to/project/package.json",
+      JSON.stringify(
+        {
+          name: "my-component-lib",
+          exports: {
+            "./button": {
+              import: "./dist/button.js",
+              require: "./dist/button.cjs",
+              types: "./dist/types/button.d.ts",
+              development: "./lib/button/index.ts",
+              sass: "./lib/button/_button.scss",
+            },
+            "./card": {
+              import: "./dist/card.js",
+              require: "./dist/card.cjs",
+              development: "./lib/card/index.ts",
+              style: "./lib/card/card.css",
+            },
+            "./card.css": "./lib/card/card.css", // New direct CSS export
+            "./css-module-component": {
+              import: "./dist/css-module-component.js",
+              require: "./dist/css-module-component.cjs",
+              development: "./lib/css-module-component/index.ts",
             },
           },
         },


### PR DESCRIPTION
This PR introduces a new `development` export condition to the `package.json` exports map. This enhancement significantly improves the developer experience for consumers of the published package.

When another project uses this package as a dependency within a development environment (like Vite), the `development` condition allows the bundler to resolve modules directly to their original source files (e.g., `.ts` files) instead of the compiled `.js` output in `dist/`. This provides a much better debugging experience, as developers can step through the original, un-transpiled code.

**Key Changes:**

- **`development` Export Condition:** The plugin now automatically adds a `development` entry to each component's export map, pointing to its source entry point.
- **`enabledDevelopment` Option:** This feature is enabled by default. It can be disabled by setting `enabledDevelopment: false` in the plugin options.
- **Testing:** Added new unit tests to verify the correct generation of the `development` condition and to ensure the feature can be disabled.

This change is fully backward compatible and does not affect production builds.